### PR TITLE
HTTP calls in hmrc.py moved to asyncio

### DIFF
--- a/gnucash_uk_vat/hmrc.py
+++ b/gnucash_uk_vat/hmrc.py
@@ -368,7 +368,6 @@ class Vat:
             vrn, quote_plus(period)
         )
 
-        print(url)
         async with aiohttp.ClientSession() as client:
             async with client.get(url, headers=headers) as resp:
                 if resp.status != 200:

--- a/gnucash_uk_vat/hmrc.py
+++ b/gnucash_uk_vat/hmrc.py
@@ -259,34 +259,28 @@ class Vat:
         }
 
     # Test fraud headers.  Only available in Sandbox, not production
-    def test_fraud_headers(self):
+    async def test_fraud_headers(self):
 
         headers = self.build_fraud_headers()
         headers['Accept'] = 'application/vnd.hmrc.1.0+json'
 
         url = self.api_base + '/test/fraud-prevention-headers/validate'
 
-        resp = requests.get(url, headers=headers)
-        if resp.status_code != 200:
-            try:
-                msg = resp.json()["message"]
-            except:
-                msg = "HTTP error %d" % resp.status_code
-            raise RuntimeError(msg)
+        async with aiohttp.ClientSession() as client:
+            async with client.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    try:
+                        msg = (await resp.json())["message"]
+                    except:
+                        msg = "HTTP error %d" % resp.status
+                    raise RuntimeError(msg)
 
-        obj = resp.json()
-
-        if resp.status_code != 200:
-            try:
-                msg = resp.json()["message"]
-            except:
-                msg = "HTTP error %d" % resp.status_code
-            raise RuntimeError(msg)
+                obj = await resp.json()
 
         return obj
 
     # API request, fetch obligations which are in state O.
-    def get_open_obligations(self, vrn):
+    async def get_open_obligations(self, vrn):
 
         headers = self.build_fraud_headers()
         headers['Accept'] = 'application/vnd.hmrc.1.0+json'
@@ -300,15 +294,16 @@ class Vat:
             urlencode(params)
         )
 
-        resp = requests.get(url, headers=headers)
-        if resp.status_code != 200:
-            try:
-                msg = resp.json()["message"]
-            except:
-                msg = "HTTP error %d" % resp.status_code
-            raise RuntimeError(msg)
+        async with aiohttp.ClientSession() as client:
+            async with client.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    try:
+                        msg = (await resp.json())["message"]
+                    except:
+                        msg = "HTTP error %d" % resp.status
+                    raise RuntimeError(msg)
 
-        obj = resp.json()
+                obj = await resp.json()
 
         if "obligations" not in obj:
             raise RuntimeError(obj["message"])
@@ -320,7 +315,7 @@ class Vat:
         return obligations
 
     # API request, fetch obligations which are in a time period.
-    def get_obligations(self, vrn, start=None, end=None):
+    async def get_obligations(self, vrn, start=None, end=None):
 
         if start == None:
             start = datetime.utcnow() - timedelta(days=(2 * 356))
@@ -341,15 +336,16 @@ class Vat:
             urlencode(params)
         )
 
-        resp = requests.get(url, headers=headers)
-        if resp.status_code != 200:
-            try:
-                msg = resp.json()["message"]
-            except:
-                msg = "HTTP error %d" % resp.status_code
-            raise RuntimeError(msg)
+        async with aiohttp.ClientSession() as client:
+            async with client.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    try:
+                        msg = (await resp.json())["message"]
+                    except:
+                        msg = "HTTP error %d" % resp.status
+                    raise RuntimeError(msg)
 
-        obj = resp.json()
+                obj = await resp.json()
 
         if "obligations" not in obj:
             raise RuntimeError(obj["message"])
@@ -359,7 +355,7 @@ class Vat:
         ]
 
     # API request, fetch a VAT return instance.
-    def get_vat_return(self, vrn, period):
+    async def get_vat_return(self, vrn, period):
 
         headers = self.build_fraud_headers()
         headers['Accept'] = 'application/vnd.hmrc.1.0+json'
@@ -372,20 +368,22 @@ class Vat:
             vrn, quote_plus(period)
         )
 
-        resp = requests.get(url, headers=headers)
-        if resp.status_code != 200:
-            try:
-                msg = resp.json()["message"]
-            except:
-                msg = "HTTP error %d" % resp.status_code
-            raise RuntimeError(msg)
+        print(url)
+        async with aiohttp.ClientSession() as client:
+            async with client.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    try:
+                        msg = (await resp.json())["message"]
+                    except:
+                        msg = "HTTP error %d" % resp.status
+                    raise RuntimeError(msg)
 
-        obj = resp.json()
+                obj = await resp.json()
 
         return Return.from_dict(obj)
 
     # API request, submit a VAT return.
-    def submit_vat_return(self, vrn, rtn):
+    async def submit_vat_return(self, vrn, rtn):
 
         headers = self.build_fraud_headers()
         headers['Accept'] = 'application/vnd.hmrc.1.0+json'
@@ -394,16 +392,17 @@ class Vat:
             vrn
         )
 
-        resp = requests.post(url, headers=headers,
-                             data=json.dumps(rtn.to_dict()))
-        if resp.status_code != 201:
-            try:
-                msg = resp.json()["message"]
-            except:
-                msg = "HTTP error %d" % resp.status_code
-            raise RuntimeError(msg)
+        async with aiohttp.ClientSession() as client:
+            async with client.post(url, headers=headers,
+                                   json=rtn.to_dict()) as resp:
+                if resp.status != 201:
+                    try:
+                        msg = (await resp.json())["message"]
+                    except:
+                        msg = "HTTP error %d" % resp.status
+                    raise RuntimeError(msg)
 
-        obj = resp.json()
+                obj = await resp.json()
 
         if "code" in obj:
             raise RuntimeError(obj["message"])
@@ -411,7 +410,7 @@ class Vat:
         return obj
 
     # Get liabilities in time period
-    def get_vat_liabilities(self, vrn, start, end):
+    async def get_vat_liabilities(self, vrn, start, end):
 
         headers = self.build_fraud_headers()
         headers['Accept'] = 'application/vnd.hmrc.1.0+json'
@@ -426,20 +425,21 @@ class Vat:
             urlencode(params)
         )
 
-        resp = requests.get(url, headers=headers)
-        if resp.status_code != 200:
-            try:
-                msg = resp.json()["message"]
-            except:
-                msg = "HTTP error %d" % resp.status_code
-            raise RuntimeError(msg)
+        async with aiohttp.ClientSession() as client:
+            async with client.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    try:
+                        msg = (await resp.json())["message"]
+                    except:
+                        msg = "HTTP error %d" % resp.status
+                    raise RuntimeError(msg)
 
-        obj = resp.json()
+                obj = await resp.json()
 
         return [Liability.from_dict(v) for v in obj["liabilities"]]
 
     # Get payments in time period
-    def get_vat_payments(self, vrn, start, end):
+    async def get_vat_payments(self, vrn, start, end):
 
         headers = self.build_fraud_headers()
         headers['Accept'] = 'application/vnd.hmrc.1.0+json'
@@ -454,15 +454,16 @@ class Vat:
             urlencode(params)
         )
 
-        resp = requests.get(url, headers=headers)
-        if resp.status_code != 200:
-            try:
-                msg = resp.json()["message"]
-            except:
-                msg = "HTTP error %d" % resp.status_code
-            raise RuntimeError(msg)
+        async with aiohttp.ClientSession() as client:
+            async with client.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    try:
+                        msg = (await resp.json())["message"]
+                    except:
+                        msg = "HTTP error %d" % resp.status
+                    raise RuntimeError(msg)
 
-        obj = resp.json()
+                obj = await resp.json()
 
         return [
             Payment.from_dict(v) for v in obj["payments"]

--- a/gnucash_uk_vat/operations.py
+++ b/gnucash_uk_vat/operations.py
@@ -19,9 +19,9 @@ async def authenticate(h, auth):
     sys.stderr.write("Wrote %s.\n" % auth.file)
 
 # Show obligations with the O state
-def show_open_obligations(h, config):
+async def show_open_obligations(h, config):
 
-    obs = h.get_open_obligations(config.get("identity.vrn"))
+    obs = await h.get_open_obligations(config.get("identity.vrn"))
 
     if len(obs) == 0:
         print("No obligations matched.")
@@ -36,9 +36,9 @@ def show_open_obligations(h, config):
                    tablefmt="pretty"))
 
 # Show obligations in a time period
-def show_obligations(start, end, h, config):
+async def show_obligations(start, end, h, config):
 
-    obs = h.get_obligations(config.get("identity.vrn"), start, end)
+    obs = await h.get_obligations(config.get("identity.vrn"), start, end)
 
     if len(obs) == 0:
         print("No obligations matched.")
@@ -54,11 +54,11 @@ def show_obligations(start, end, h, config):
                    tablefmt="pretty"))
 
 # Submit a VAT return
-def submit_vat_return(due, h, config):
+async def submit_vat_return(due, h, config):
 
     # We need start/end information, but only have a due date.
     # Load the obligations to get the mapping
-    obs = h.get_open_obligations(config.get("identity.vrn"))
+    obs = await h.get_open_obligations(config.get("identity.vrn"))
 
     # Iterate over obligations to find the period
     obl = None
@@ -107,7 +107,7 @@ declaration can result in prosecution.
         print("Answer not recognised.")
 
     # Call the API
-    resp = h.submit_vat_return(config.get("identity.vrn"), rtn)
+    resp = await h.submit_vat_return(config.get("identity.vrn"), rtn)
 
     # Dump out the response
     print()
@@ -122,11 +122,11 @@ declaration can result in prosecution.
         print("%-30s: %s" % ("Charge ref", resp["chargeRefNumber"]))
 
 # Submit a VAT return
-def post_vat_bill(start, end, due, h, config):
+async def post_vat_bill(start, end, due, h, config):
 
     # We need start/end information, but only have a period key first.
     # Load the obligations to get the mapping
-    obs = h.get_obligations(config.get("identity.vrn"), start, end)
+    obs = await h.get_obligations(config.get("identity.vrn"), start, end)
 
     # Iterate over obligations to find the period
     obl = None
@@ -175,10 +175,10 @@ def post_vat_bill(start, end, due, h, config):
     print("Bill posted.")
 
 # Show GnuCash information relating to open VAT obligations
-def show_account_data(h, config, due, detail=False):
+async def show_account_data(h, config, due, detail=False):
 
     # Get open obligations
-    obs = h.get_open_obligations(config.get("identity.vrn"))
+    obs = await h.get_open_obligations(config.get("identity.vrn"))
 
     # Iterate over obligations to find the period
     obl = None
@@ -242,11 +242,11 @@ def show_account_data(h, config, due, detail=False):
             print()
 
 # Dump out a VAT return
-def show_vat_return(start, end, due, h, config):
+async def show_vat_return(start, end, due, h, config):
 
     # We need start/end information, but only have a period key first.
     # Load the obligations to get the mapping
-    obs = h.get_obligations(config.get("identity.vrn"), start, end)
+    obs = await h.get_obligations(config.get("identity.vrn"), start, end)
 
     # Iterate over obligations to find the period
     obl = None
@@ -258,14 +258,14 @@ def show_vat_return(start, end, due, h, config):
         raise RuntimeError("Due date '%s' does not match any obligation" % due)
 
     # Fetch VAT return data
-    rtn = h.get_vat_return(config.get("identity.vrn"), obl.periodKey)
+    rtn = await h.get_vat_return(config.get("identity.vrn"), obl.periodKey)
     sys.stdout.write(rtn.to_string())
 
 # Show liabilities
-def show_liabilities(start, end, h, config):
+async def show_liabilities(start, end, h, config):
 
     # Fetch values from liabilities endpoint
-    rtn = h.get_vat_liabilities(config.get("identity.vrn"), start, end)
+    rtn = await h.get_vat_liabilities(config.get("identity.vrn"), start, end)
 
     # Initialise empty table
     tbl = []
@@ -284,10 +284,10 @@ def show_liabilities(start, end, h, config):
     print(tabulate(tbl, ["Period End", "Type", "Amount", "Outstanding", "Due"],
                    tablefmt="pretty"))
 
-def show_payments(start, end, h, config):
+async def show_payments(start, end, h, config):
 
     # Fetch values from payments endpoint
-    rtn = h.get_vat_payments(config.get("identity.vrn"), start, end)
+    rtn = await h.get_vat_payments(config.get("identity.vrn"), start, end)
 
     # Initialise empty table
     tbl = []
@@ -302,3 +302,4 @@ def show_payments(start, end, h, config):
     # Dump out table
     print(tabulate(tbl, ["Amount", "Received"],
                    tablefmt="pretty"))
+

--- a/scripts/gnucash-uk-vat
+++ b/scripts/gnucash-uk-vat
@@ -95,18 +95,18 @@ async def run():
 
     # Call appropriate function to implement operations
     if args.show_open_obligations:
-        show_open_obligations(h, config)
+        await show_open_obligations(h, config)
         sys.exit(0)
     elif args.show_obligations:
         start = datetime.fromisoformat(args.start).date()
         end = datetime.fromisoformat(args.end).date()
-        show_obligations(start, end, h, config)
+        await show_obligations(start, end, h, config)
         sys.exit(0)
     elif args.submit_vat_return:
         if args.due_date == None:
             raise RuntimeError("--due-date must be specified")
         due = datetime.fromisoformat(args.due_date).date()
-        submit_vat_return(due, h, config)
+        await submit_vat_return(due, h, config)
         sys.exit(0)
 #    elif args.post_vat_bill:
 #        start = datetime.fromisoformat(args.start).date()
@@ -120,13 +120,13 @@ async def run():
         if args.due_date == None:
             raise RuntimeError("--due-date must be specified")
         due = datetime.fromisoformat(args.due_date).date()
-        show_account_data(h, config, due, detail=True)
+        await show_account_data(h, config, due, detail=True)
         sys.exit(0)
     elif args.show_account_summary:
         if args.due_date == None:
             raise RuntimeError("--due-date must be specified")
         due = datetime.fromisoformat(args.due_date).date()
-        show_account_data(h, config, due)
+        await show_account_data(h, config, due)
         sys.exit(0)
     elif args.show_vat_return:
         start = datetime.fromisoformat(args.start).date()
@@ -134,17 +134,17 @@ async def run():
         if args.due_date == None:
             raise RuntimeError("--due-date must be specified")
         due = datetime.fromisoformat(args.due_date).date()
-        show_vat_return(start, end, due, h, config)
+        await show_vat_return(start, end, due, h, config)
         sys.exit(0)
     elif args.show_liabilities:
         start = datetime.fromisoformat(args.start).date()
         end = datetime.fromisoformat(args.end).date()
-        show_liabilities(start, end, h, config)
+        await show_liabilities(start, end, h, config)
         sys.exit(0)
     elif args.show_payments:
         start = datetime.fromisoformat(args.start).date()
         end = datetime.fromisoformat(args.end).date()
-        show_payments(start, end, h, config)
+        await show_payments(start, end, h, config)
         sys.exit(0)
     else:
         raise RuntimeError("No operation specified.  Try --assist option.")


### PR DESCRIPTION
- Ported HTTP calls from requests to aiohttp client to allow the code to be used in async applications.
- Ported assist.py to async, needed to add a background event loop for the VAT API calls.
