### PR TITLE
Added HMRC tooling used for sandbox testing

### DIFF
--- a/hmrc-tools/README.md
+++ b/hmrc-tools/README.md
@@ -1,0 +1,11 @@
+
+Here are a couple of tools used for testing against the HMRC VAT MTD
+sandbox.  There are client ID / secrets hard-coded into the scripts, you
+need to set them to your sandbox values.  This is not for use in the live
+environment or with production credentials.
+
+- get-fraud-feedback: This code connects to the HMRC sandbox Fraud API and
+  fetches feedback on compliance with Fraud API requirements.
+- get-test-user: Connects to the Test User API and creates a new user for
+  VAT MTD testing.
+

--- a/hmrc-tools/get-fraud-feedback
+++ b/hmrc-tools/get-fraud-feedback
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# This code connects to the HMRC sandbox Fraud API and fetches feedback
+# on compliance with Fraud API requirements.
+
+import requests
+import json
+import sys
+
+# Add your client ID and secret here
+client_id = "CLIENT_ID"
+client_secret = "CLIENT_SECRET"
+
+headers = {
+    "content-type": "application/x-www-form-urlencoded",
+}
+
+data = {
+    "client_secret": client_secret,
+    "client_id": client_id,
+    "grant_type": "client_credentials",
+    "scope": "read:vat",
+}
+
+resp = requests.post(
+    "https://test-api.service.hmrc.gov.uk/oauth/token", headers=headers,
+    data=data
+)
+
+if resp.status_code != 200:
+    print(resp.text)
+    sys.exit(1)
+
+token = resp.json()["access_token"]
+
+headers = {
+    "Authorization": "Bearer " + token,
+    "Accept": "application/vnd.hmrc.1.0+json",
+}
+
+url = "https://test-api.service.hmrc.gov.uk/test/fraud-prevention-headers/vat-mtd/validation-feedback?connectionMethod=WEB_APP_VIA_SERVER"
+
+resp = requests.get(url, headers=headers)
+if resp.status_code != 200:
+    print(resp.text)
+    sys.exit(1)
+
+#print(json.dumps(resp.json(), indent=4))
+
+results = resp.json()
+results = results["requests"]
+
+for req in results:
+
+    print("Path %s %s..." % (req["method"], req["path"]))
+    print("  Time: %s" % req["requestTimestamp"])
+    print("  Result: %s" % req["code"])
+
+    for hdr in req["headers"]:
+        print("    %-35s: %s" % (hdr["header"], hdr["code"]))
+

--- a/hmrc-tools/get-test-user
+++ b/hmrc-tools/get-test-user
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# This code connects to the HMRC test user API and provisions a new sandbox
+# test user, outputting the gov ID, password and VRN.
+
+import requests
+import json
+import sys
+
+# Add your client ID and secret here
+client_id = "CLIENT_ID"
+client_secret = "CLIENT_SECRET"
+
+headers = {
+    "content-type": "application/x-www-form-urlencoded",
+}
+
+data = {
+    "client_secret": client_secret,
+    "client_id": client_id,
+    "grant_type": "client_credentials",
+    "scope": "read:vat",
+}
+
+resp = requests.post(
+    "https://test-api.service.hmrc.gov.uk/oauth/token", headers=headers,
+    data=data
+)
+
+if resp.status_code != 200:
+    print(resp.text)
+    sys.exit(1)
+
+token = resp.json()["access_token"]
+
+headers = {
+    "Authorization": "Bearer " + token,
+    "Content-Type": "application/json",
+    "Accept": "application/vnd.hmrc.1.0+json",
+}
+
+data = {
+    "serviceNames": [
+        "mtd-vat",
+    ],
+}
+
+url = "https://test-api.service.hmrc.gov.uk/create-test-user/organisations"
+
+resp = requests.post(url, data=json.dumps(data), headers=headers)
+if resp.status_code != 201:
+    print(resp.text)
+    sys.exit(1)
+
+#print(json.dumps(resp.json(), indent=4))
+
+user = resp.json()
+
+def present(x):
+    return x
+
+print("User:      ", present(user["userId"]))
+print("Password:  ", present(user["password"]))
+print("VRN:       ", present(user["vrn"]))
+


### PR DESCRIPTION
- get-fraud-feedback: This code connects to the HMRC sandbox Fraud API and
  fetches feedback on compliance with Fraud API requirements.
- get-test-user: Connects to the Test User API and creates a new user for
  VAT MTD testing.