### PR TITLE
Fix timestamp format

### DIFF
--- a/gnucash_uk_vat/config.py
+++ b/gnucash_uk_vat/config.py
@@ -136,7 +136,7 @@ def initialise_config(config_path: Path, user: Optional['Config']) -> None:
             "local-ip": local_ip,
             "mac-address": mac,
             # https://developer.service.hmrc.gov.uk/guides/fraud-prevention/connection-method/other-direct/#gov-client-local-ips-timestamp
-            "time": now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            "time": now().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
         }
     }
 


### PR DESCRIPTION
The existing timestamp isn't correct and ends up with a weird truncated offset.
Instead of hacking the ISO format, this explicitly requests the exact format HMRC requires.