### PR TITLE
Fix error comparing TZ-naive to TZ-set datetime in auth

### DIFF
--- a/gnucash_uk_vat/auth.py
+++ b/gnucash_uk_vat/auth.py
@@ -40,6 +40,7 @@ class Auth:
         if "expires" not in self.auth:
             raise RuntimeError("No token expiry.  Have you authenticated?")
         expires = datetime.fromisoformat(self.auth["expires"])
+        expires = expires.replace(tzinfo=timezone.utc)
         if  datetime.now(timezone.utc) > expires:
             await self.refresh(svc)
 

--- a/gnucash_uk_vat/hmrc.py
+++ b/gnucash_uk_vat/hmrc.py
@@ -180,6 +180,12 @@ class Vat:
             async with client.post(url, headers=headers, data=params) as resp:
                 res = await resp.json()
 
+        # Check for required fields in response
+        required_fields = ["access_token", "refresh_token", "token_type", "expires_in"]
+        missing_fields = [field for field in required_fields if field not in res]
+        if missing_fields:
+            raise RuntimeError(f"OAuth response missing required fields: {missing_fields}. Response: {res}")
+
         # Turn expiry period into a datetime
         expiry = now + timedelta(seconds=int(res["expires_in"]))
         expiry = expiry.replace(microsecond=0)
@@ -223,6 +229,12 @@ class Vat:
         async with aiohttp.ClientSession() as client:
             async with client.post(url, headers=headers, data=params) as resp:
                 res = await resp.json()
+
+        # Check for required fields in response
+        required_fields = ["access_token", "refresh_token", "token_type", "expires_in"]
+        missing_fields = [field for field in required_fields if field not in res]
+        if missing_fields:
+            raise RuntimeError(f"OAuth response missing required fields: {missing_fields}. Response: {res}")
 
         expiry = now + timedelta(seconds=int(res["expires_in"]))
         expiry = expiry.replace(microsecond=0)


### PR DESCRIPTION
Error loading auth...
```
    if  datetime.now(timezone.utc) > expires:
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```
