### PR TITLE
Fix default kind selection in assist

### DIFF
--- a/gnucash_uk_vat/assist.py
+++ b/gnucash_uk_vat/assist.py
@@ -134,6 +134,7 @@ class FileSelection:
                 self.check()
                 
         rb1 = Gtk.RadioButton.new_from_widget(None)
+        self.kind = "gnucash"
         self.ui.select_kind("gnucash")
         rb1.set_label("gnucash")
         rb1.connect("toggled", toggled, "gnucash")


### PR DESCRIPTION
Fix:
```
Traceback (most recent call last):
  File "/home/s/Hacking/gnucash-uk-vat/gnucash_uk_vat/assist.py", line 111, in select
    self.check()
  File "/home/s/Hacking/gnucash-uk-vat/gnucash_uk_vat/assist.py", line 162, in check
    k = self.kind
AttributeError: 'FileSelection' object has no attribute 'kind'
```