### PR TITLE
Default to oldest obligation in UI

### DIFF
--- a/gnucash_uk_vat/assist.py
+++ b/gnucash_uk_vat/assist.py
@@ -397,7 +397,7 @@ class SelectObligation:
             if w.get_active():
                 self.ui.select_obligation(ob)
 
-        for v in obls:
+        for v in reversed(obls):
             rb = Gtk.RadioButton.new_from_widget(grp)
             if grp == None:
                 grp = rb


### PR DESCRIPTION
Current code always defaults to the newest obligation, which is always for a period which hasn't finished yet, meaning that you shouldn't be trying to submit it.

This reverses the order, so the oldest obligation is the default, which should be pretty much always the one a user is going to want to submit.